### PR TITLE
Fixed '__session' name for Cloud Functions and Cloud Run

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,26 @@ express() // or connect
   } ) );
 ```
 
+## Usage in Cloud Functions or Cloud Run
+
+When using Firebase Hosting together with Cloud Functions or Cloud Run, cookies are stripped from incoming requests. This would normally prevent the session lookup mechanism from working. However, when using `__session` as the name, the value will be passed through to the app.
+
+```javascript
+express() // or connect
+  .use( session( {
+    store:  new FirestoreStore( {
+      database: database
+    } ),
+
+    name:              '__session', // ← required for Cloud Functions / Cloud Run
+    secret:            'keyboard cat',
+    resave:            true,
+    saveUninitialized: true
+  } ) );
+```
+
+Refer to [Using Cookies in the Firebase Documentation on Caching](https://firebase.google.com/docs/hosting/manage-cache#using_cookies)
+
 
 ## Options
 


### PR DESCRIPTION
I had some issues using this in Cloud Functions for Firebase, i.e. running Cloud Functions behind Firebase Hosting. Setting the name to a fixed value of `__session` helps make this work, so I extended the readme accordingly.

This addresses #8 

Without this property, everything works in the emulator, but unfortunately not when deployed to a real function.

Edits in this commit are allowed, but let me know, if I should add something.